### PR TITLE
Update project status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ reliable _real-time_ applications.
 
 ## Status
 
-_The Apache DistributedLog project is in the process of incubating. This includes the creation of project resources,
-the refactoring of the initial code submissions, and the formulation of project documentation, planning and the
-improvements of existing user and operation documents. Any feedback and contributions are welcome._
+_Apache DistributedLog project graduated from Incubator at July 2017. It is now a sub-project of Apache BookKeeper._
+
+The core components of _Apache DistributedLog_ has been merged as part of _Apache BookKeeper_. The development of _Apache DistributedLog_ has been moved under BookKeeper.
+See [BP-26: Move distributedlog library as part of bookkeeper](http://bookkeeper.apache.org/bps/BP-26-move-distributedlog-core-library/) for more details.
 
 ## Features
 


### PR DESCRIPTION
Update the project status in the README to match the status found in https://github.com/apache/distributedlog. This should help direct people to where the code now lives if they end up at this repo through old links and such.